### PR TITLE
Fix description of YT-DLP

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Feel free to contribute!
 * [you-get](https://github.com/soimort/you-get): Dumb downloader that scrapes the web
 
 * [ytdl-sub](https://github.com/jmbannon/ytdl-sub): Automate downloading and metadata generation with YouTubeDL
-* [yt-dlp](https://github.com/yt-dlp/yt-dlp): A fork of YT-DLP that behaves better
+* [yt-dlp](https://github.com/yt-dlp/yt-dlp): A fork of youtube-dl that behaves better
 ### Application-specific
 * [BBCSoundDownloader](https://github.com/FThompson/BBCSoundDownloader): Bulk downloader for BBC's Sound Effects library http://bbcsfx.acropolis.org.uk/
 * [ChanThreadWatch](https://github.com/SuperGouge/ChanThreadWatch): Saves threads from \*chan-style boards and checks for updates until the thread dies


### PR DESCRIPTION
YT-DLP must be a fork of youtube-dl, not itself.